### PR TITLE
Implement pure Python star chart generator

### DIFF
--- a/configs/demo.yaml
+++ b/configs/demo.yaml
@@ -1,0 +1,55 @@
+seed: 2411
+name: demo
+resolution:
+  width: 2048
+  height: 2048
+  ssaa: 1
+camera:
+  tilt_deg: 32
+  fov_deg: 35
+rings:
+  - r: 0.32
+    width: 0.008
+    color: "#1E90FF"
+    dash: [10, 4]
+    ticks_every_deg: 10
+    label: "ORBITAL NODE 20.64 Mσ"
+  - r: 0.42
+    width: 0.007
+    color: "#FF3B2F"
+    dash: [12, 5]
+    ticks_every_deg: 15
+    label: "SECTOR 3A"
+    label_angle_deg: 120
+  - r: 0.54
+    width: 0.006
+    color: "#FFC107"
+    ticks_every_deg: 20
+    label: "RELAY 7"
+stars:
+  core:
+    sigma: 0.20
+    alpha: 3.2
+    count: 5500
+  halo:
+    count: 2200
+    min_r: 0.35
+    max_r: 1.05
+  brightness_power: 1.9
+  min_size_px: 0.6
+  max_size_px: 2.5
+text:
+  font: null
+  size_px: 32
+  color: "#e6f5ff"
+  tracking: -0.6
+  tabular_digits: true
+post:
+  bloom:
+    threshold: 0.9
+    intensity: 0.36
+    radius: 16
+  chromatic_aberration:
+    k: 0.0018
+  vignette: 0.14
+  grain: 0.012

--- a/configs/denso.yaml
+++ b/configs/denso.yaml
@@ -1,0 +1,60 @@
+seed: 12981
+name: dense
+resolution:
+  width: 3072
+  height: 4096
+  ssaa: 1
+camera:
+  tilt_deg: 28
+  fov_deg: 32
+rings:
+  - r: 0.28
+    width: 0.01
+    color: "#00B5FF"
+    dash: [8, 3]
+    ticks_every_deg: 12
+    label: "PRIMARY LATTICE"
+  - r: 0.36
+    width: 0.008
+    color: "#FF6A00"
+    ticks_every_deg: 15
+    label: "DATA STACK 4"
+    label_angle_deg: 40
+  - r: 0.44
+    width: 0.007
+    color: "#FF3B2F"
+    dash: [14, 6]
+    ticks_every_deg: 18
+    label: "SINGULARITY VECTOR"
+  - r: 0.62
+    width: 0.006
+    color: "#1E90FF"
+    ticks_every_deg: 20
+    label: "COORD SHIELD"
+stars:
+  core:
+    sigma: 0.18
+    alpha: 3.4
+    count: 8000
+  halo:
+    count: 3200
+    min_r: 0.30
+    max_r: 1.05
+  brightness_power: 1.7
+  min_size_px: 0.6
+  max_size_px: 2.9
+text:
+  font: null
+  size_px: 34
+  color: "#dff6ff"
+  tracking: -0.65
+  tabular_digits: true
+post:
+  bloom:
+    threshold: 0.85
+    intensity: 0.34
+    radius: 18
+  chromatic_aberration:
+    k: 0.0024
+  vignette: 0.15
+  grain: 0.014

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# This project now depends only on the Python standard library.

--- a/scripts/generate_star_chart.py
+++ b/scripts/generate_star_chart.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""CLI entry point for the star chart generator."""
+from __future__ import annotations
+
+import argparse
+import struct
+import zlib
+from pathlib import Path
+from typing import Dict
+
+from star_chart_generator import SceneConfig, generate_star_chart
+from star_chart_generator.image import FloatImage
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render a star chart from a YAML config")
+    parser.add_argument("config", type=Path, help="Path to the scene YAML configuration")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        type=Path,
+        help="Destination image file (defaults to config name with .png)",
+    )
+    parser.add_argument(
+        "--output",
+        dest="output_override",
+        type=Path,
+        help="Explicit destination image path",
+    )
+    parser.add_argument("--seed", type=int, help="Override the RNG seed for rendering")
+    parser.add_argument(
+        "--layers-dir",
+        type=Path,
+        help="If provided, saves intermediate layers (PNG) into this directory",
+    )
+    parser.add_argument(
+        "--compare",
+        type=Path,
+        help="Compute the mean absolute difference against a reference PNG",
+    )
+    return parser.parse_args()
+
+
+def _save_layers(layers: Dict[str, FloatImage], directory: Path) -> None:
+    directory.mkdir(parents=True, exist_ok=True)
+    for name, data in layers.items():
+        data.save_png(str(directory / f"{name}.png"))
+
+
+def _load_png(path: Path) -> FloatImage:
+    with path.open("rb") as fh:
+        data = fh.read()
+    if not data.startswith(b"\x89PNG\r\n\x1a\n"):
+        raise ValueError("Unsupported PNG signature")
+    offset = 8
+    width = height = None
+    pixels = b""
+    while offset < len(data):
+        length = struct.unpack_from(">I", data, offset)[0]
+        offset += 4
+        tag = data[offset : offset + 4]
+        offset += 4
+        payload = data[offset : offset + length]
+        offset += length
+        crc = data[offset : offset + 4]
+        offset += 4
+        if tag == b"IHDR":
+            width, height, bit_depth, color_type, _, _, _ = struct.unpack(">IIBBBBB", payload)
+            if bit_depth != 8 or color_type != 2:
+                raise ValueError("Only 8-bit RGB PNGs are supported")
+        elif tag == b"IDAT":
+            pixels += payload
+        elif tag == b"IEND":
+            break
+    decompressed = zlib.decompress(pixels)
+    image = FloatImage.new(width, height, 0.0)
+    stride = width * 3 + 1
+    for y in range(height):
+        row = decompressed[y * stride : (y + 1) * stride]
+        if row[0] != 0:
+            raise ValueError("Only PNG filter 0 supported")
+        for x in range(width):
+            r = row[1 + 3 * x] / 255.0
+            g = row[1 + 3 * x + 1] / 255.0
+            b = row[1 + 3 * x + 2] / 255.0
+            image.pixels[y][x][0] = r
+            image.pixels[y][x][1] = g
+            image.pixels[y][x][2] = b
+    return image
+
+
+def _mean_abs_diff(a: FloatImage, b: FloatImage) -> float:
+    if a.width != b.width or a.height != b.height:
+        raise ValueError("Images must share the same dimensions for comparison")
+    total = 0.0
+    count = a.width * a.height * 3
+    for y in range(a.height):
+        for x in range(a.width):
+            pa = a.pixels[y][x]
+            pb = b.pixels[y][x]
+            total += abs(pa[0] - pb[0]) + abs(pa[1] - pb[1]) + abs(pa[2] - pb[2])
+    return total / count
+
+
+def main() -> None:
+    args = parse_args()
+    config = SceneConfig.load(args.config)
+    result = generate_star_chart(config, seed=args.seed)
+
+    output_path = args.output_override or args.output
+    if output_path is None:
+        output_path = args.config.with_suffix(".png")
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    result.save(str(output_path))
+
+    if args.layers_dir:
+        _save_layers(result.layers, args.layers_dir)
+
+    if args.compare:
+        reference = _load_png(args.compare)
+        diff = _mean_abs_diff(result.image, reference)
+        print(f"Mean absolute difference vs {args.compare}: {diff:.6f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/star_chart_generator/__init__.py
+++ b/src/star_chart_generator/__init__.py
@@ -1,0 +1,7 @@
+"""Star chart generator package."""
+from __future__ import annotations
+
+from .config import SceneConfig
+from .render import RenderResult, generate_star_chart
+
+__all__ = ["SceneConfig", "RenderResult", "generate_star_chart"]

--- a/src/star_chart_generator/config.py
+++ b/src/star_chart_generator/config.py
@@ -1,0 +1,362 @@
+"""Configuration structures for the star chart generator."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import ast
+import math
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover - fallback to pure python parser
+    yaml = None
+
+
+@dataclass(frozen=True)
+class Resolution:
+    """Output resolution configuration."""
+
+    width: int
+    height: int
+    ssaa: int = 1
+
+    def supersampled(self) -> tuple[int, int]:
+        """Return the supersampled resolution (width, height)."""
+        return self.width * self.ssaa, self.height * self.ssaa
+
+
+@dataclass(frozen=True)
+class Camera:
+    """Camera orientation used for ring projection."""
+
+    tilt_deg: float = 32.0
+    fov_deg: float = 35.0
+
+    @property
+    def tilt_radians(self) -> float:
+        return math.radians(self.tilt_deg)
+
+    @property
+    def ellipse_ratio(self) -> float:
+        """Approximate squish factor for the vertical axis of the rings."""
+        return math.cos(self.tilt_radians)
+
+
+@dataclass(frozen=True)
+class RingConfig:
+    """Parameters describing a single UI ring."""
+
+    r: float
+    width: float
+    color: str
+    dash: Optional[Sequence[float]] = None
+    ticks_every_deg: Optional[float] = None
+    label: Optional[str] = None
+    label_angle_deg: Optional[float] = None
+    label_offset: float = 0.015
+    glow: float = 1.0
+    halo_color: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class CoreDistribution:
+    """Configuration for the dense stellar core."""
+
+    sigma: float
+    alpha: float
+    count: int
+
+
+@dataclass(frozen=True)
+class HaloDistribution:
+    """Configuration for the sparse halo of stars."""
+
+    count: int
+    min_r: float
+    max_r: float
+
+
+@dataclass(frozen=True)
+class StarConfig:
+    """Aggregate settings for star sampling."""
+
+    core: CoreDistribution
+    halo: HaloDistribution
+    brightness_power: float = 1.8
+    min_size_px: float = 0.6
+    max_size_px: float = 2.8
+    color_jitter: float = 0.08
+
+
+@dataclass(frozen=True)
+class TextConfig:
+    """Typography settings."""
+
+    font: Optional[str] = None
+    size_px: int = 26
+    color: str = "#e6f5ff"
+    tracking: float = -0.5
+    tabular_digits: bool = True
+
+
+@dataclass(frozen=True)
+class BloomConfig:
+    threshold: float = 1.1
+    intensity: float = 0.32
+    radius: float = 18.0
+
+
+@dataclass(frozen=True)
+class ChromaticAberrationConfig:
+    k: float = 0.0015
+
+
+@dataclass(frozen=True)
+class PostConfig:
+    bloom: BloomConfig = field(default_factory=BloomConfig)
+    chromatic_aberration: ChromaticAberrationConfig = field(
+        default_factory=ChromaticAberrationConfig
+    )
+    vignette: float = 0.12
+    grain: float = 0.015
+
+
+@dataclass(frozen=True)
+class SceneConfig:
+    """Top level configuration for a star chart scene."""
+
+    seed: int
+    resolution: Resolution
+    camera: Camera
+    rings: List[RingConfig]
+    stars: StarConfig
+    text: TextConfig = field(default_factory=TextConfig)
+    post: PostConfig = field(default_factory=PostConfig)
+    lut: Optional[str] = None
+    name: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any], *, base_path: Optional[Path] = None) -> "SceneConfig":
+        """Construct a :class:`SceneConfig` from a dictionary."""
+
+        resolution_data = data.get("resolution", {})
+        resolution = Resolution(
+            width=int(resolution_data["width"]),
+            height=int(resolution_data["height"]),
+            ssaa=int(resolution_data.get("ssaa", 1)),
+        )
+
+        camera_data = data.get("camera", {})
+        camera = Camera(
+            tilt_deg=float(camera_data.get("tilt_deg", 32.0)),
+            fov_deg=float(camera_data.get("fov_deg", 35.0)),
+        )
+
+        rings = [
+            RingConfig(
+                r=float(item["r"]),
+                width=float(item.get("width", 0.006)),
+                color=str(item["color"]),
+                dash=tuple(item.get("dash", [])) or None,
+                ticks_every_deg=float(item["ticks_every_deg"])
+                if "ticks_every_deg" in item
+                else None,
+                label=item.get("label"),
+                label_angle_deg=float(item["label_angle_deg"])
+                if "label_angle_deg" in item
+                else None,
+                label_offset=float(item.get("label_offset", 0.015)),
+                glow=float(item.get("glow", 1.0)),
+                halo_color=str(item.get("halo_color", item.get("color", "#ffffff"))),
+            )
+            for item in data.get("rings", [])
+        ]
+
+        stars_data = data.get("stars", {})
+        core_data = stars_data.get("core", {})
+        halo_data = stars_data.get("halo", {})
+        stars = StarConfig(
+            core=CoreDistribution(
+                sigma=float(core_data.get("sigma", 0.18)),
+                alpha=float(core_data.get("alpha", 3.2)),
+                count=int(core_data.get("count", 18000)),
+            ),
+            halo=HaloDistribution(
+                count=int(halo_data.get("count", 6000)),
+                min_r=float(halo_data.get("min_r", 0.35)),
+                max_r=float(halo_data.get("max_r", 1.0)),
+            ),
+            brightness_power=float(stars_data.get("brightness_power", 1.8)),
+            min_size_px=float(stars_data.get("min_size_px", 0.6)),
+            max_size_px=float(stars_data.get("max_size_px", 2.8)),
+            color_jitter=float(stars_data.get("color_jitter", 0.08)),
+        )
+
+        text_data = data.get("text", {})
+        text = TextConfig(
+            font=text_data.get("font"),
+            size_px=int(text_data.get("size_px", 26)),
+            color=str(text_data.get("color", "#e6f5ff")),
+            tracking=float(text_data.get("tracking", -0.5)),
+            tabular_digits=bool(text_data.get("tabular_digits", True)),
+        )
+
+        post_data = data.get("post", {})
+        bloom_data = post_data.get("bloom", {})
+        chromatic_data = post_data.get("chromatic_aberration", {})
+        post = PostConfig(
+            bloom=BloomConfig(
+                threshold=float(bloom_data.get("threshold", 1.1)),
+                intensity=float(bloom_data.get("intensity", 0.32)),
+                radius=float(bloom_data.get("radius", 18.0)),
+            ),
+            chromatic_aberration=ChromaticAberrationConfig(
+                k=float(chromatic_data.get("k", 0.0015))
+            ),
+            vignette=float(post_data.get("vignette", 0.12)),
+            grain=float(post_data.get("grain", 0.015)),
+        )
+
+        seed = int(data.get("seed", 1))
+        name = data.get("name")
+        lut = data.get("lut") or data.get("post", {}).get("lut")
+
+        return cls(
+            seed=seed,
+            resolution=resolution,
+            camera=camera,
+            rings=rings,
+            stars=stars,
+            text=text,
+            post=post,
+            lut=lut,
+            name=name,
+        )
+
+    @classmethod
+    def load(cls, path: Path) -> "SceneConfig":
+        """Load configuration from a YAML file."""
+        text = Path(path).read_text(encoding="utf8")
+        data = _load_yaml(text)
+        if not isinstance(data, dict):
+            raise ValueError("Configuration root must be a mapping")
+        return cls.from_dict(data, base_path=Path(path).parent)
+
+
+def _load_yaml(text: str) -> Any:
+    if yaml is not None:  # pragma: no cover - exercised when PyYAML is available
+        return yaml.safe_load(text)
+    return _simple_yaml_load(text)
+
+
+def _simple_yaml_load(text: str) -> Any:
+    lines = []
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip(" "))
+        lines.append((indent, stripped))
+    value, _ = _parse_block(lines, 0, 0)
+    return value
+
+
+def _parse_block(lines: List[Tuple[int, str]], index: int, indent: int) -> Tuple[Any, int]:
+    if index >= len(lines):
+        return {}, index
+    level, content = lines[index]
+    if content.startswith("- ") and level == indent:
+        return _parse_list(lines, index, indent)
+    result: Dict[str, Any] = {}
+    while index < len(lines):
+        level, content = lines[index]
+        if level < indent or content.startswith("- "):
+            break
+        if ":" not in content:
+            index += 1
+            continue
+        key, remainder = content.split(":", 1)
+        key = key.strip()
+        remainder = remainder.strip()
+        index += 1
+        if remainder:
+            result[key] = _parse_scalar(remainder)
+        else:
+            value, index = _parse_block(lines, index, indent + 2)
+            result[key] = value
+    return result, index
+
+
+def _parse_list(lines: List[Tuple[int, str]], index: int, indent: int) -> Tuple[List[Any], int]:
+    items: List[Any] = []
+    while index < len(lines):
+        level, content = lines[index]
+        if level < indent or not content.startswith("- "):
+            break
+        remainder = content[2:].strip()
+        index += 1
+        if remainder:
+            if ":" in remainder:
+                key, value_part = remainder.split(":", 1)
+                key = key.strip()
+                value_part = value_part.strip()
+                item: Dict[str, Any] = {}
+                item[key] = _parse_scalar(value_part) if value_part else None
+                if value_part == "":
+                    subvalue, index = _parse_block(lines, index, indent + 2)
+                    item[key] = subvalue
+                else:
+                    subvalue, index = _parse_block(lines, index, indent + 2)
+                    if isinstance(subvalue, dict):
+                        item.update(subvalue)
+                items.append(item)
+            else:
+                items.append(_parse_scalar(remainder))
+        else:
+            value, index = _parse_block(lines, index, indent + 2)
+            items.append(value)
+    return items, index
+
+
+def _parse_scalar(token: str) -> Any:
+    if token.startswith("\"") and token.endswith("\""):
+        return token[1:-1]
+    if token.startswith("'") and token.endswith("'"):
+        return token[1:-1]
+    lowered = token.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered == "null":
+        return None
+    if token.startswith("[") or token.startswith("{"):
+        return ast.literal_eval(token)
+    try:
+        if token.startswith("0x"):
+            return int(token, 16)
+        return int(token)
+    except ValueError:
+        pass
+    try:
+        return float(token)
+    except ValueError:
+        pass
+    return token
+
+
+__all__ = [
+    "Resolution",
+    "Camera",
+    "RingConfig",
+    "CoreDistribution",
+    "HaloDistribution",
+    "StarConfig",
+    "TextConfig",
+    "BloomConfig",
+    "ChromaticAberrationConfig",
+    "PostConfig",
+    "SceneConfig",
+]

--- a/src/star_chart_generator/image.py
+++ b/src/star_chart_generator/image.py
@@ -1,0 +1,247 @@
+"""Minimal float RGB image utilities with PNG serialization."""
+from __future__ import annotations
+
+import math
+import struct
+import zlib
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence, Tuple
+
+
+Color = Tuple[float, float, float]
+
+
+@dataclass
+class FloatImage:
+    width: int
+    height: int
+    pixels: List[List[List[float]]]
+
+    @classmethod
+    def new(cls, width: int, height: int, fill: float = 0.0) -> "FloatImage":
+        rows = [[[fill, fill, fill] for _ in range(width)] for _ in range(height)]
+        return cls(width=width, height=height, pixels=rows)
+
+    def copy(self) -> "FloatImage":
+        return FloatImage(
+            width=self.width,
+            height=self.height,
+            pixels=[[pixel[:] for pixel in row] for row in self.pixels],
+        )
+
+    def add_pixel(self, x: int, y: int, color: Color, intensity: float = 1.0) -> None:
+        if 0 <= x < self.width and 0 <= y < self.height:
+            pixel = self.pixels[y][x]
+            pixel[0] += color[0] * intensity
+            pixel[1] += color[1] * intensity
+            pixel[2] += color[2] * intensity
+
+    def get_pixel(self, x: int, y: int) -> Color:
+        pixel = self.pixels[y][x]
+        return (pixel[0], pixel[1], pixel[2])
+
+    def add_gaussian(self, cx: float, cy: float, sigma: float, intensity: float, color: Color) -> None:
+        if sigma <= 0:
+            return
+        radius = max(1, int(sigma * 3.0))
+        x0 = max(0, int(cx) - radius)
+        x1 = min(self.width, int(cx) + radius + 1)
+        y0 = max(0, int(cy) - radius)
+        y1 = min(self.height, int(cy) + radius + 1)
+        two_sigma_sq = 2.0 * sigma * sigma
+        for y in range(y0, y1):
+            dy = y - cy
+            for x in range(x0, x1):
+                dx = x - cx
+                value = math.exp(-(dx * dx + dy * dy) / two_sigma_sq)
+                self.add_pixel(x, y, color, intensity * value)
+
+    def add_disc(self, cx: float, cy: float, radius: float, color: Color, intensity: float = 1.0) -> None:
+        r2 = radius * radius
+        x0 = max(0, int(cx - radius - 1))
+        x1 = min(self.width, int(cx + radius + 2))
+        y0 = max(0, int(cy - radius - 1))
+        y1 = min(self.height, int(cy + radius + 2))
+        for y in range(y0, y1):
+            dy = y - cy
+            for x in range(x0, x1):
+                dx = x - cx
+                if dx * dx + dy * dy <= r2:
+                    self.add_pixel(x, y, color, intensity)
+
+    def add_line(self, p0: Tuple[float, float], p1: Tuple[float, float], color: Color, width: int = 1, intensity: float = 1.0) -> None:
+        x0, y0 = p0
+        x1, y1 = p1
+        dx = x1 - x0
+        dy = y1 - y0
+        length = max(abs(dx), abs(dy))
+        if length == 0:
+            self.add_disc(x0, y0, width * 0.5, color, intensity)
+            return
+        steps = int(length) + 1
+        for i in range(steps + 1):
+            t = i / max(steps, 1)
+            x = x0 + dx * t
+            y = y0 + dy * t
+            self.add_disc(x, y, max(0.5, width * 0.5), color, intensity)
+
+    def apply_map(self, func) -> None:
+        for y in range(self.height):
+            row = self.pixels[y]
+            for x in range(self.width):
+                r, g, b = row[x]
+                row[x][0], row[x][1], row[x][2] = func(r, g, b)
+
+    def multiply(self, factor: float) -> None:
+        for y in range(self.height):
+            row = self.pixels[y]
+            for x in range(self.width):
+                row[x][0] *= factor
+                row[x][1] *= factor
+                row[x][2] *= factor
+
+    def add_image(self, other: "FloatImage") -> None:
+        for y in range(self.height):
+            row = self.pixels[y]
+            other_row = other.pixels[y]
+            for x in range(self.width):
+                row[x][0] += other_row[x][0]
+                row[x][1] += other_row[x][1]
+                row[x][2] += other_row[x][2]
+
+    def add_scaled_image(self, other: "FloatImage", scale: float) -> None:
+        for y in range(self.height):
+            row = self.pixels[y]
+            other_row = other.pixels[y]
+            for x in range(self.width):
+                row[x][0] += other_row[x][0] * scale
+                row[x][1] += other_row[x][1] * scale
+                row[x][2] += other_row[x][2] * scale
+
+    def clamp(self, lo: float = 0.0, hi: float = 1.0) -> None:
+        for y in range(self.height):
+            for x in range(self.width):
+                pixel = self.pixels[y][x]
+                pixel[0] = min(max(pixel[0], lo), hi)
+                pixel[1] = min(max(pixel[1], lo), hi)
+                pixel[2] = min(max(pixel[2], lo), hi)
+
+    def downsample(self, factor: int) -> "FloatImage":
+        if factor <= 1:
+            return self.copy()
+        new_width = self.width // factor
+        new_height = self.height // factor
+        output = FloatImage.new(new_width, new_height, 0.0)
+        for y in range(new_height):
+            for x in range(new_width):
+                acc = [0.0, 0.0, 0.0]
+                for yy in range(factor):
+                    for xx in range(factor):
+                        pixel = self.pixels[y * factor + yy][x * factor + xx]
+                        acc[0] += pixel[0]
+                        acc[1] += pixel[1]
+                        acc[2] += pixel[2]
+                scale = 1.0 / (factor * factor)
+                output.pixels[y][x][0] = acc[0] * scale
+                output.pixels[y][x][1] = acc[1] * scale
+                output.pixels[y][x][2] = acc[2] * scale
+        return output
+
+    def to_uint8_rows(self) -> List[bytearray]:
+        rows: List[bytearray] = []
+        for y in range(self.height):
+            row_bytes = bytearray()
+            row_bytes.append(0)  # filter type 0
+            for x in range(self.width):
+                r, g, b = self.pixels[y][x]
+                row_bytes.append(int(min(max(r, 0.0), 1.0) * 255.0 + 0.5))
+                row_bytes.append(int(min(max(g, 0.0), 1.0) * 255.0 + 0.5))
+                row_bytes.append(int(min(max(b, 0.0), 1.0) * 255.0 + 0.5))
+            rows.append(row_bytes)
+        return rows
+
+    def save_png(self, path: str) -> None:
+        rows = self.to_uint8_rows()
+        data = b"".join(rows)
+        compressed = zlib.compress(data, level=6)
+
+        def chunk(tag: bytes, payload: bytes) -> bytes:
+            return (
+                struct.pack(">I", len(payload))
+                + tag
+                + payload
+                + struct.pack(">I", zlib.crc32(tag + payload) & 0xFFFFFFFF)
+            )
+
+        ihdr = struct.pack(">IIBBBBB", self.width, self.height, 8, 2, 0, 0, 0)
+        with open(path, "wb") as fh:
+            fh.write(b"\x89PNG\r\n\x1a\n")
+            fh.write(chunk(b"IHDR", ihdr))
+            fh.write(chunk(b"IDAT", compressed))
+            fh.write(chunk(b"IEND", b""))
+
+    def sample(self, x: float, y: float) -> Color:
+        if x < 0 or x >= self.width - 1 or y < 0 or y >= self.height - 1:
+            ix = min(max(int(x), 0), self.width - 1)
+            iy = min(max(int(y), 0), self.height - 1)
+            pixel = self.pixels[iy][ix]
+            return pixel[0], pixel[1], pixel[2]
+        x0 = int(math.floor(x))
+        y0 = int(math.floor(y))
+        x1 = x0 + 1
+        y1 = y0 + 1
+        wx = x - x0
+        wy = y - y0
+        p00 = self.pixels[y0][x0]
+        p01 = self.pixels[y0][x1]
+        p10 = self.pixels[y1][x0]
+        p11 = self.pixels[y1][x1]
+        top = [p00[c] * (1 - wx) + p01[c] * wx for c in range(3)]
+        bottom = [p10[c] * (1 - wx) + p11[c] * wx for c in range(3)]
+        return tuple(top[c] * (1 - wy) + bottom[c] * wy for c in range(3))
+
+
+def gaussian_blur(image: FloatImage, sigma: float) -> FloatImage:
+    if sigma <= 0:
+        return image.copy()
+    radius = max(1, int(math.ceil(sigma * 3.0)))
+    kernel = [math.exp(-(i * i) / (2.0 * sigma * sigma)) for i in range(-radius, radius + 1)]
+    kernel_sum = sum(kernel)
+    kernel = [k / kernel_sum for k in kernel]
+
+    # Horizontal pass
+    temp = FloatImage.new(image.width, image.height, 0.0)
+    for y in range(image.height):
+        for x in range(image.width):
+            acc = [0.0, 0.0, 0.0]
+            for k, weight in enumerate(kernel):
+                xx = x + k - radius
+                if 0 <= xx < image.width:
+                    src = image.pixels[y][xx]
+                    acc[0] += src[0] * weight
+                    acc[1] += src[1] * weight
+                    acc[2] += src[2] * weight
+            temp.pixels[y][x][0] = acc[0]
+            temp.pixels[y][x][1] = acc[1]
+            temp.pixels[y][x][2] = acc[2]
+
+    # Vertical pass
+    output = FloatImage.new(image.width, image.height, 0.0)
+    for y in range(image.height):
+        for x in range(image.width):
+            acc = [0.0, 0.0, 0.0]
+            for k, weight in enumerate(kernel):
+                yy = y + k - radius
+                if 0 <= yy < image.height:
+                    src = temp.pixels[yy][x]
+                    acc[0] += src[0] * weight
+                    acc[1] += src[1] * weight
+                    acc[2] += src[2] * weight
+            output.pixels[y][x][0] = acc[0]
+            output.pixels[y][x][1] = acc[1]
+            output.pixels[y][x][2] = acc[2]
+
+    return output
+
+
+__all__ = ["FloatImage", "gaussian_blur", "Color"]

--- a/src/star_chart_generator/labels.py
+++ b/src/star_chart_generator/labels.py
@@ -1,0 +1,204 @@
+"""Curved text layout using a built-in bitmap font."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+import math
+
+from .config import TextConfig
+from .image import FloatImage
+from .utils import hex_to_rgb
+
+Glyph = List[str]
+
+FONT_DATA: Dict[str, Glyph] = {
+    "A": ["  #  ", " # # ", "#   #", "#####", "#   #", "#   #", "#   #"],
+    "B": ["#### ", "#   #", "#   #", "#### ", "#   #", "#   #", "#### "],
+    "C": [" ####", "#    ", "#    ", "#    ", "#    ", "#    ", " ####"],
+    "D": ["###  ", "#  # ", "#   #", "#   #", "#   #", "#  # ", "###  "],
+    "E": ["#####", "#    ", "#    ", "#### ", "#    ", "#    ", "#####"],
+    "F": ["#####", "#    ", "#    ", "#### ", "#    ", "#    ", "#    "],
+    "G": [" ### ", "#   #", "#    ", "# ###", "#   #", "#   #", " ### "],
+    "H": ["#   #", "#   #", "#   #", "#####", "#   #", "#   #", "#   #"],
+    "I": [" ### ", "  #  ", "  #  ", "  #  ", "  #  ", "  #  ", " ### "],
+    "J": ["  ###", "   #", "   #", "   #", "#  #", "#  #", " ## "],
+    "K": ["#   #", "#  # ", "# #  ", "##   ", "# #  ", "#  # ", "#   #"],
+    "L": ["#    ", "#    ", "#    ", "#    ", "#    ", "#    ", "#####"],
+    "M": ["#   #", "## ##", "# # #", "#   #", "#   #", "#   #", "#   #"],
+    "N": ["#   #", "##  #", "# # #", "#  ##", "#   #", "#   #", "#   #"],
+    "O": [" ### ", "#   #", "#   #", "#   #", "#   #", "#   #", " ### "],
+    "P": ["#### ", "#   #", "#   #", "#### ", "#    ", "#    ", "#    "],
+    "Q": [" ### ", "#   #", "#   #", "#   #", "# # #", "#  # ", " ## #"],
+    "R": ["#### ", "#   #", "#   #", "#### ", "# #  ", "#  # ", "#   #"],
+    "S": [" ####", "#    ", "#    ", " ### ", "    #", "    #", "#### "],
+    "T": ["#####", "  #  ", "  #  ", "  #  ", "  #  ", "  #  ", "  #  "],
+    "U": ["#   #", "#   #", "#   #", "#   #", "#   #", "#   #", " ### "],
+    "V": ["#   #", "#   #", "#   #", "#   #", " # # ", " # # ", "  #  "],
+    "W": ["#   #", "#   #", "#   #", "# # #", "# # #", "## ##", "#   #"],
+    "X": ["#   #", "#   #", " # # ", "  #  ", " # # ", "#   #", "#   #"],
+    "Y": ["#   #", "#   #", " # # ", "  #  ", "  #  ", "  #  ", "  #  "],
+    "Z": ["#####", "    #", "   # ", "  #  ", " #   ", "#    ", "#####"],
+    "0": [" ### ", "#   #", "#  ##", "# # #", "##  #", "#   #", " ### "],
+    "1": ["  #  ", " ##  ", "# #  ", "  #  ", "  #  ", "  #  ", "#####"],
+    "2": [" ### ", "#   #", "    #", "   # ", "  #  ", " #   ", "#####"],
+    "3": [" ### ", "#   #", "    #", "  ## ", "    #", "#   #", " ### "],
+    "4": ["   # ", "  ## ", " # # ", "#  # ", "#####", "   # ", "   # "],
+    "5": ["#####", "#    ", "#### ", "    #", "    #", "#   #", " ### "],
+    "6": [" ### ", "#   #", "#    ", "#### ", "#   #", "#   #", " ### "],
+    "7": ["#####", "    #", "   # ", "   # ", "  #  ", "  #  ", "  #  "],
+    "8": [" ### ", "#   #", "#   #", " ### ", "#   #", "#   #", " ### "],
+    "9": [" ### ", "#   #", "#   #", " ####", "    #", "#   #", " ### "],
+    "-": ["     ", "     ", "     ", " ### ", "     ", "     ", "     "],
+    ":": ["     ", "  #  ", "     ", "     ", "     ", "  #  ", "     "],
+    ".": ["     ", "     ", "     ", "     ", "     ", "  ## ", "  ## "],
+    " ": ["     ", "     ", "     ", "     ", "     ", "     ", "     "],
+}
+
+GLYPH_WIDTH = 5
+GLYPH_HEIGHT = 7
+
+
+@dataclass
+class LabelSpec:
+    ring_index: int
+    text: str
+    center: Tuple[float, float]
+    radius_x: float
+    radius_y: float
+    initial_angle: float
+    tracking: float
+    scale: float
+
+
+@dataclass
+class LabelPlacement:
+    spec: LabelSpec
+    theta: float
+    arc_angle: float
+    advances: List[float]
+
+
+def _glyph(char: str) -> Glyph:
+    return FONT_DATA.get(char.upper(), FONT_DATA[" "])
+
+
+def _glyph_advance(char: str) -> float:
+    glyph = _glyph(char)
+    width = max(len(row) for row in glyph)
+    return float(width + 1)
+
+
+def _text_advances(text: str, tracking: float) -> List[float]:
+    advances: List[float] = []
+    for index, char in enumerate(text):
+        advance = _glyph_advance(char)
+        if index < len(text) - 1:
+            advance += tracking / 6.0
+        advances.append(max(0.4, advance))
+    return advances
+
+
+def _wrap(angle: float) -> float:
+    return (angle + math.pi) % (2.0 * math.pi) - math.pi
+
+
+def layout_labels(
+    specs: Sequence[LabelSpec],
+    *,
+    padding: float = 0.06,
+    iterations: int = 140,
+) -> List[LabelPlacement]:
+    placements: List[LabelPlacement] = []
+    for spec in specs:
+        effective_radius = max((spec.radius_x + spec.radius_y) * 0.5, 1.0)
+        advances = _text_advances(spec.text, spec.tracking)
+        arc_length = sum(advances) * spec.scale
+        arc_angle = arc_length / effective_radius
+        placements.append(
+            LabelPlacement(
+                spec=spec,
+                theta=spec.initial_angle,
+                arc_angle=arc_angle,
+                advances=advances,
+            )
+        )
+
+    by_ring: Dict[int, List[LabelPlacement]] = {}
+    for placement in placements:
+        by_ring.setdefault(placement.spec.ring_index, []).append(placement)
+
+    for ring_placements in by_ring.values():
+        if len(ring_placements) <= 1:
+            continue
+        for _ in range(iterations):
+            moved = False
+            for i in range(len(ring_placements)):
+                for j in range(i + 1, len(ring_placements)):
+                    a = ring_placements[i]
+                    b = ring_placements[j]
+                    diff = _wrap(b.theta - a.theta)
+                    min_sep = (a.arc_angle + b.arc_angle) * 0.5 + padding
+                    if abs(diff) < min_sep:
+                        direction = 1.0 if diff >= 0 else -1.0
+                        shift = (min_sep - abs(diff)) * 0.5
+                        a.theta -= direction * shift
+                        b.theta += direction * shift
+                        moved = True
+            if not moved:
+                break
+        for placement in ring_placements:
+            placement.theta = _wrap(placement.theta)
+
+    ordered: List[LabelPlacement] = []
+    for spec in specs:
+        for placement in placements:
+            if placement.spec is spec:
+                ordered.append(placement)
+                break
+    return ordered
+
+
+def _draw_glyph(image: FloatImage, glyph: Glyph, center: Tuple[float, float], scale: float, rotation: float, color: Tuple[float, float, float], intensity: float) -> None:
+    cx, cy = center
+    angle = math.radians(rotation)
+    cos_a = math.cos(angle)
+    sin_a = math.sin(angle)
+    for y, row in enumerate(glyph):
+        for x, ch in enumerate(row):
+            if ch != "#":
+                continue
+            px = (x - GLYPH_WIDTH / 2.0) * scale
+            py = (y - GLYPH_HEIGHT / 2.0) * scale
+            rx = px * cos_a - py * sin_a
+            ry = px * sin_a + py * cos_a
+            image.add_disc(cx + rx, cy + ry, max(0.5, scale * 0.45), color, intensity)
+
+
+def draw_label_layers(
+    size: Tuple[int, int],
+    placements: Sequence[LabelPlacement],
+    text_config: TextConfig,
+) -> Tuple[FloatImage, FloatImage]:
+    width, height = size
+    core = FloatImage.new(width, height, 0.0)
+    glow = FloatImage.new(width, height, 0.0)
+    base_color = hex_to_rgb(text_config.color)
+    for placement in placements:
+        scale = placement.spec.scale
+        effective_radius = max((placement.spec.radius_x + placement.spec.radius_y) * 0.5, 1.0)
+        theta = placement.theta - placement.arc_angle / 2.0
+        for advance, char in zip(placement.advances, placement.spec.text):
+            theta += (advance * scale) / (2.0 * effective_radius)
+            x = placement.spec.center[0] + placement.spec.radius_x * math.cos(theta)
+            y = placement.spec.center[1] + placement.spec.radius_y * math.sin(theta)
+            rotation = math.degrees(theta) - 90.0
+            glyph = _glyph(char)
+            _draw_glyph(core, glyph, (x, y), scale, rotation, base_color, 1.0)
+            _draw_glyph(glow, glyph, (x, y), scale * 1.6, rotation, base_color, 0.2)
+            theta += (advance * scale) / (2.0 * effective_radius)
+
+    return core, glow
+
+
+__all__ = ["LabelSpec", "LabelPlacement", "layout_labels", "draw_label_layers"]

--- a/src/star_chart_generator/post.py
+++ b/src/star_chart_generator/post.py
@@ -1,0 +1,100 @@
+"""Post-processing operations implemented in pure Python."""
+from __future__ import annotations
+
+import math
+import random
+from typing import Tuple
+
+from .image import FloatImage, gaussian_blur
+
+
+def apply_bloom(image: FloatImage, threshold: float, intensity: float, radius: float) -> FloatImage:
+    bright = FloatImage.new(image.width, image.height, 0.0)
+    for y in range(image.height):
+        for x in range(image.width):
+            r, g, b = image.get_pixel(x, y)
+            bright.pixels[y][x][0] = max(r - threshold, 0.0)
+            bright.pixels[y][x][1] = max(g - threshold, 0.0)
+            bright.pixels[y][x][2] = max(b - threshold, 0.0)
+    blurred = gaussian_blur(bright, max(1.0, radius / 3.0))
+    result = image.copy()
+    result.add_scaled_image(blurred, intensity)
+    return result
+
+
+def apply_chromatic_aberration(image: FloatImage, k: float) -> FloatImage:
+    if abs(k) < 1e-6:
+        return image.copy()
+    result = FloatImage.new(image.width, image.height, 0.0)
+    cx = (image.width - 1) / 2.0
+    cy = (image.height - 1) / 2.0
+    for y in range(image.height):
+        for x in range(image.width):
+            dx = x - cx
+            dy = y - cy
+            radius = math.sqrt(dx * dx + dy * dy) + 1e-6
+            shift = k * (radius ** 2)
+            nx = dx / radius
+            ny = dy / radius
+            red_sample = image.sample(x + nx * shift, y + ny * shift)
+            green_sample = image.sample(x, y)
+            blue_sample = image.sample(x - nx * shift, y - ny * shift)
+            result.pixels[y][x][0] = red_sample[0]
+            result.pixels[y][x][1] = green_sample[1]
+            result.pixels[y][x][2] = blue_sample[2]
+    return result
+
+
+def apply_vignette(image: FloatImage, strength: float) -> FloatImage:
+    if strength <= 0:
+        return image.copy()
+    result = image.copy()
+    cx = (image.width - 1) / 2.0
+    cy = (image.height - 1) / 2.0
+    max_radius = math.sqrt(cx * cx + cy * cy)
+    for y in range(image.height):
+        for x in range(image.width):
+            dx = x - cx
+            dy = y - cy
+            factor = 1.0 - strength * ((math.sqrt(dx * dx + dy * dy) / max_radius) ** 1.5)
+            factor = max(0.0, min(1.0, factor))
+            pixel = result.pixels[y][x]
+            pixel[0] *= factor
+            pixel[1] *= factor
+            pixel[2] *= factor
+    return result
+
+
+def add_grain(image: FloatImage, amount: float, rng: random.Random) -> FloatImage:
+    if amount <= 0:
+        return image.copy()
+    result = image.copy()
+    for y in range(image.height):
+        for x in range(image.width):
+            noise = rng.gauss(0.0, amount)
+            pixel = result.pixels[y][x]
+            pixel[0] = max(0.0, pixel[0] + noise)
+            pixel[1] = max(0.0, pixel[1] + noise)
+            pixel[2] = max(0.0, pixel[2] + noise)
+    return result
+
+
+def tone_map_aces(image: FloatImage) -> FloatImage:
+    result = image.copy()
+    a, b, c, d, e = 2.51, 0.03, 2.43, 0.59, 0.14
+    for y in range(image.height):
+        for x in range(image.width):
+            pixel = result.pixels[y][x]
+            for i in range(3):
+                value = pixel[i]
+                pixel[i] = max(0.0, min(1.0, (value * (a * value + b)) / (value * (c * value + d) + e)))
+    return result
+
+
+__all__ = [
+    "apply_bloom",
+    "apply_chromatic_aberration",
+    "apply_vignette",
+    "add_grain",
+    "tone_map_aces",
+]

--- a/src/star_chart_generator/render.py
+++ b/src/star_chart_generator/render.py
@@ -1,0 +1,66 @@
+"""High level rendering orchestrator."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import random
+
+from .config import SceneConfig
+from .image import FloatImage
+from .post import add_grain, apply_bloom, apply_chromatic_aberration, apply_vignette, tone_map_aces
+from .sampling import downsample, generate_star_field, render_star_field
+from .shapes import render_ui_layers
+
+
+@dataclass
+class RenderResult:
+    image: FloatImage
+    layers: Dict[str, FloatImage]
+
+    def save(self, path: str) -> None:
+        self.image.save_png(path)
+
+
+def generate_star_chart(config: SceneConfig, *, seed: Optional[int] = None) -> RenderResult:
+    rng = random.Random(seed if seed is not None else config.seed)
+
+    stars = generate_star_field(config.stars, config.resolution, config.camera, rng)
+    star_layer = render_star_field(stars, config.resolution)
+    ui_core, ui_glow = render_ui_layers(config, config.resolution.supersampled())
+
+    combined = star_layer.copy()
+    combined.add_image(ui_core)
+    combined.add_image(ui_glow)
+
+    bloom = apply_bloom(
+        combined,
+        threshold=config.post.bloom.threshold,
+        intensity=config.post.bloom.intensity,
+        radius=config.post.bloom.radius,
+    )
+    aberrated = apply_chromatic_aberration(bloom, config.post.chromatic_aberration.k)
+    vignetted = apply_vignette(aberrated, config.post.vignette)
+    grained = add_grain(vignetted, config.post.grain, rng)
+    final_linear = tone_map_aces(grained)
+
+    ssaa = config.resolution.ssaa
+    if ssaa > 1:
+        star_layer = downsample(star_layer, ssaa)
+        ui_core = downsample(ui_core, ssaa)
+        ui_glow = downsample(ui_glow, ssaa)
+        final_linear = downsample(final_linear, ssaa)
+
+    final_linear.clamp(0.0, 1.0)
+
+    layers = {
+        "stars": star_layer,
+        "ui_core": ui_core,
+        "ui_glow": ui_glow,
+        "final_linear": final_linear.copy(),
+    }
+
+    return RenderResult(image=final_linear, layers=layers)
+
+
+__all__ = ["RenderResult", "generate_star_chart"]

--- a/src/star_chart_generator/sampling.py
+++ b/src/star_chart_generator/sampling.py
@@ -1,0 +1,99 @@
+"""Procedural generation of the stellar field."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import math
+import random
+
+from .config import Camera, Resolution, StarConfig
+from .image import FloatImage
+from .utils import mix_colors
+
+Color = Tuple[float, float, float]
+
+
+@dataclass
+class Star:
+    x: float
+    y: float
+    radius: float
+    intensity: float
+    color: Color
+
+
+def _sersic_radius(rng: random.Random, sigma: float, alpha: float) -> float:
+    u = max(min(rng.random(), 1.0 - 1e-6), 1e-6)
+    value = sigma * (-math.log(1.0 - u)) ** (1.0 / max(alpha, 1e-3))
+    return min(max(value, 0.0), 1.0)
+
+
+def _halo_radius(rng: random.Random, r_min: float, r_max: float) -> float:
+    if r_max <= r_min:
+        r_max = r_min + 1e-3
+    u = rng.random()
+    return math.sqrt(u * (r_max * r_max - r_min * r_min) + r_min * r_min)
+
+
+def _color_from_intensity(intensity: float) -> Color:
+    cold = (0.18, 0.65, 1.0)
+    hot = (1.0, 0.42, 0.18)
+    t = min(max(intensity, 0.0), 1.0)
+    return mix_colors(cold, hot, t)
+
+
+def generate_star_field(
+    config: StarConfig,
+    resolution: Resolution,
+    camera: Camera,
+    rng: random.Random,
+) -> List[Star]:
+    width, height = resolution.supersampled()
+    base_radius = min(width, height) * 0.5 * 0.92
+    ellipse_ratio = camera.ellipse_ratio
+    cx, cy = width / 2.0, height / 2.0
+
+    stars: List[Star] = []
+
+    for _ in range(config.core.count):
+        theta = rng.random() * math.tau
+        radius = _sersic_radius(rng, config.core.sigma, config.core.alpha)
+        intensity = (1.0 - rng.random()) ** (1.0 / config.brightness_power)
+        color = _color_from_intensity(intensity)
+        size = config.min_size_px + intensity * (config.max_size_px - config.min_size_px)
+        rx = base_radius * radius
+        ry = rx * ellipse_ratio
+        x = cx + rx * math.cos(theta)
+        y = cy + ry * math.sin(theta)
+        stars.append(Star(x=x, y=y, radius=size, intensity=intensity * 1.35, color=color))
+
+    for _ in range(config.halo.count):
+        theta = rng.random() * math.tau
+        radius = _halo_radius(rng, config.halo.min_r, config.halo.max_r)
+        intensity = (1.0 - rng.random()) ** (1.0 / (config.brightness_power + 0.4))
+        color = _color_from_intensity(intensity * 0.8)
+        size = config.min_size_px * 0.75 + intensity * (config.max_size_px - config.min_size_px)
+        rx = base_radius * radius
+        ry = rx * ellipse_ratio
+        x = cx + rx * math.cos(theta)
+        y = cy + ry * math.sin(theta)
+        stars.append(Star(x=x, y=y, radius=size, intensity=intensity, color=color))
+
+    return stars
+
+
+def render_star_field(stars: List[Star], resolution: Resolution) -> FloatImage:
+    width, height = resolution.supersampled()
+    image = FloatImage.new(width, height, 0.0)
+    for star in stars:
+        sigma = max(0.5, star.radius / 2.0)
+        image.add_gaussian(star.x, star.y, sigma, star.intensity, star.color)
+    return image
+
+
+def downsample(image: FloatImage, factor: int) -> FloatImage:
+    return image.downsample(factor)
+
+
+__all__ = ["Star", "generate_star_field", "render_star_field", "downsample"]

--- a/src/star_chart_generator/shapes.py
+++ b/src/star_chart_generator/shapes.py
@@ -1,0 +1,107 @@
+"""Drawing helpers for UI elements using the custom image buffer."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List, Tuple
+
+import math
+
+from .config import SceneConfig
+from .image import FloatImage, gaussian_blur
+from .labels import LabelSpec, draw_label_layers, layout_labels
+from .utils import hex_to_rgb
+
+
+def _draw_arc(image: FloatImage, center: Tuple[float, float], rx: float, ry: float, start_deg: float, end_deg: float, width: float, color: Tuple[float, float, float], intensity: float) -> None:
+    steps = max(12, int(abs(end_deg - start_deg) * max(rx, ry) * 0.05))
+    for i in range(steps + 1):
+        t = start_deg + (end_deg - start_deg) * (i / max(steps, 1))
+        angle = math.radians(t)
+        x = center[0] + rx * math.cos(angle)
+        y = center[1] + ry * math.sin(angle)
+        image.add_disc(x, y, max(0.5, width / 2.0), color, intensity)
+
+
+def _draw_dashed_ring(image: FloatImage, center: Tuple[float, float], rx: float, ry: float, width: float, dash: Tuple[float, float], color: Tuple[float, float, float], intensity: float) -> None:
+    dash_len, gap_len = dash
+    angle = 0.0
+    while angle < 360.0:
+        start = angle
+        end = min(angle + dash_len, 360.0)
+        _draw_arc(image, center, rx, ry, start, end, width, color, intensity)
+        angle += dash_len + gap_len
+
+
+def _draw_ticks(image: FloatImage, center: Tuple[float, float], rx: float, ry: float, tick_spacing: float, tick_length: float, color: Tuple[float, float, float], width: float) -> None:
+    count = max(1, int(360.0 / tick_spacing))
+    cx, cy = center
+    for i in range(count):
+        angle = math.radians(i * tick_spacing)
+        x_inner = cx + rx * math.cos(angle)
+        y_inner = cy + ry * math.sin(angle)
+        x_outer = cx + (rx + tick_length) * math.cos(angle)
+        y_outer = cy + (ry + tick_length) * math.sin(angle)
+        image.add_line((x_inner, y_inner), (x_outer, y_outer), color, int(max(1, width)), 1.0)
+
+
+def render_ui_layers(config: SceneConfig, resolution: Tuple[int, int]) -> Tuple[FloatImage, FloatImage]:
+    width, height = resolution
+    center = (width / 2.0, height / 2.0)
+    ellipse_ratio = config.camera.ellipse_ratio
+    base_radius = min(width, height) * 0.5 * 0.92
+
+    core = FloatImage.new(width, height, 0.0)
+    glow = FloatImage.new(width, height, 0.0)
+
+    label_specs: List[LabelSpec] = []
+    label_scale = max(1.0, config.text.size_px / (7 * 2.0))
+
+    for index, ring in enumerate(config.rings):
+        rx = base_radius * ring.r
+        ry = rx * ellipse_ratio
+        stroke = max(1.0, ring.width * base_radius)
+        tick_length = max(stroke * 1.5, base_radius * 0.01)
+
+        color = hex_to_rgb(ring.color)
+        halo_color = hex_to_rgb(ring.halo_color or ring.color)
+
+        if ring.dash:
+            dash = (float(ring.dash[0]), float(ring.dash[1] if len(ring.dash) > 1 else ring.dash[0]))
+            _draw_dashed_ring(core, center, rx, ry, stroke, dash, color, 1.0)
+            _draw_dashed_ring(glow, center, rx, ry, stroke * 1.8, dash, halo_color, 0.35 * ring.glow)
+        else:
+            _draw_arc(core, center, rx, ry, 0.0, 360.0, stroke, color, 1.0)
+            _draw_arc(glow, center, rx, ry, 0.0, 360.0, stroke * 1.8, halo_color, 0.35 * ring.glow)
+
+        if ring.ticks_every_deg:
+            _draw_ticks(core, center, rx, ry, ring.ticks_every_deg, tick_length, color, stroke * 0.5)
+
+        if ring.label:
+            label_radius = ring.r + ring.width * 0.5 + ring.label_offset
+            label_rx = base_radius * label_radius
+            label_ry = label_rx * ellipse_ratio
+            angle = math.radians(ring.label_angle_deg) if ring.label_angle_deg is not None else math.pi / 2
+            label_specs.append(
+                LabelSpec(
+                    ring_index=index,
+                    text=ring.label,
+                    center=center,
+                    radius_x=label_rx,
+                    radius_y=label_ry,
+                    initial_angle=angle,
+                    tracking=config.text.tracking,
+                    scale=label_scale,
+                )
+            )
+
+    if label_specs:
+        placements = layout_labels(label_specs)
+        label_core, label_glow = draw_label_layers((width, height), placements, config.text)
+        core.add_image(label_core)
+        glow.add_image(gaussian_blur(label_glow, 2.0))
+
+    glow = gaussian_blur(glow, 3.0)
+    return core, glow
+
+
+__all__ = ["render_ui_layers"]

--- a/src/star_chart_generator/utils.py
+++ b/src/star_chart_generator/utils.py
@@ -1,0 +1,69 @@
+"""Utility helpers shared across the generator modules."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence, Tuple
+
+
+def clamp(value: float, lo: float, hi: float) -> float:
+    """Clamp ``value`` between ``lo`` and ``hi``."""
+
+    return max(lo, min(hi, value))
+
+
+def hex_to_rgb(color: str) -> Tuple[float, float, float]:
+    """Convert a hex color string into an RGB tuple with floats in ``[0, 1]``."""
+
+    color = color.strip()
+    if color.startswith("#"):
+        color = color[1:]
+    if len(color) not in (3, 6):
+        raise ValueError(f"Unsupported color format: {color!r}")
+    if len(color) == 3:
+        color = "".join(ch * 2 for ch in color)
+    r = int(color[0:2], 16)
+    g = int(color[2:4], 16)
+    b = int(color[4:6], 16)
+    return (r / 255.0, g / 255.0, b / 255.0)
+
+
+def rgb_to_rgba(color: Sequence[float], alpha: float = 1.0) -> Tuple[int, int, int, int]:
+    """Convert an ``RGB`` float tuple to 8-bit RGBA."""
+
+    r, g, b = color
+    a = clamp(alpha, 0.0, 1.0)
+    return (
+        int(clamp(r, 0.0, 1.0) * 255 + 0.5),
+        int(clamp(g, 0.0, 1.0) * 255 + 0.5),
+        int(clamp(b, 0.0, 1.0) * 255 + 0.5),
+        int(a * 255 + 0.5),
+    )
+
+
+def mix_colors(color_a: Sequence[float], color_b: Sequence[float], t: float) -> Tuple[float, float, float]:
+    """Linearly mix ``color_a`` and ``color_b``."""
+
+    t = clamp(t, 0.0, 1.0)
+    return tuple((1.0 - t) * a + t * b for a, b in zip(color_a, color_b))
+
+
+def ensure_path(candidate: Optional[str], *, search_paths: Sequence[Path]) -> Optional[Path]:
+    """Return the first existing path matching ``candidate`` in ``search_paths``."""
+
+    if not candidate:
+        return None
+    path = Path(candidate)
+    if path.is_file():
+        return path
+    for base in search_paths:
+        probe = base / candidate
+        if probe.is_file():
+            return probe
+        if not probe.suffix:
+            ttf = probe.with_suffix(".ttf")
+            if ttf.is_file():
+                return ttf
+    return None
+
+
+__all__ = ["clamp", "hex_to_rgb", "rgb_to_rgba", "mix_colors", "ensure_path"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import math
+
+from star_chart_generator.config import TextConfig
+from star_chart_generator.labels import LabelSpec, draw_label_layers, layout_labels
+
+
+def _angle_diff(a: float, b: float) -> float:
+    return ((a - b + math.pi) % (2 * math.pi)) - math.pi
+
+
+def test_label_layout_resolves_collisions():
+    text_config = TextConfig(size_px=24, tracking=-0.4)
+    center = (320.0, 260.0)
+    scale = max(1.0, text_config.size_px / (7 * 2.0))
+    specs = [
+        LabelSpec(
+            ring_index=0,
+            text="ALPHA QUADRANT",
+            center=center,
+            radius_x=190.0,
+            radius_y=140.0,
+            initial_angle=math.pi / 2,
+            tracking=text_config.tracking,
+            scale=scale,
+        ),
+        LabelSpec(
+            ring_index=0,
+            text="BETA QUADRANT",
+            center=center,
+            radius_x=190.0,
+            radius_y=140.0,
+            initial_angle=math.pi / 2 + 0.08,
+            tracking=text_config.tracking,
+            scale=scale,
+        ),
+        LabelSpec(
+            ring_index=0,
+            text="GAMMA",
+            center=center,
+            radius_x=190.0,
+            radius_y=140.0,
+            initial_angle=math.pi / 2 - 0.06,
+            tracking=text_config.tracking,
+            scale=scale,
+        ),
+    ]
+
+    placements = layout_labels(specs)
+    assert len(placements) == len(specs)
+
+    for i in range(len(placements)):
+        for j in range(i + 1, len(placements)):
+            a = placements[i]
+            b = placements[j]
+            diff = abs(_angle_diff(a.theta, b.theta))
+            required = (a.arc_angle + b.arc_angle) / 2 + 0.05
+            assert diff + 1e-3 >= required
+
+    core, glow = draw_label_layers((640, 520), placements, text_config)
+    core_energy = sum(channel for row in core.pixels for pixel in row for channel in pixel)
+    glow_energy = sum(channel for row in glow.pixels for pixel in row for channel in pixel)
+    assert core_energy > 0.0
+    assert glow_energy > 0.0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from star_chart_generator import SceneConfig, generate_star_chart
+
+
+def test_generate_star_chart(tmp_path: Path):
+    config = SceneConfig.from_dict(
+        {
+            "seed": 900,
+            "resolution": {"width": 256, "height": 256, "ssaa": 1},
+            "camera": {"tilt_deg": 30, "fov_deg": 35},
+            "rings": [
+                {
+                    "r": 0.32,
+                    "width": 0.01,
+                    "color": "#1E90FF",
+                    "ticks_every_deg": 15,
+                    "label": "GATEWAY",
+                },
+                {
+                    "r": 0.45,
+                    "width": 0.008,
+                    "color": "#FF6A00",
+                    "dash": [10, 4],
+                    "ticks_every_deg": 20,
+                    "label": "ARRAY",
+                    "label_angle_deg": 120,
+                },
+            ],
+            "stars": {
+                "core": {"sigma": 0.2, "alpha": 3.1, "count": 200},
+                "halo": {"count": 120, "min_r": 0.4, "max_r": 1.0},
+                "brightness_power": 1.7,
+                "min_size_px": 0.5,
+                "max_size_px": 2.0,
+            },
+            "text": {"size_px": 20, "color": "#e8f2ff", "tracking": -0.5},
+            "post": {
+                "bloom": {"threshold": 0.85, "intensity": 0.32, "radius": 12},
+                "chromatic_aberration": {"k": 0.0015},
+                "vignette": 0.12,
+                "grain": 0.0,
+            },
+        }
+    )
+
+    result = generate_star_chart(config, seed=123)
+    assert result.image.width == config.resolution.width
+    assert result.image.height == config.resolution.height
+    assert set(result.layers.keys()) >= {"stars", "ui_core", "ui_glow", "final_linear"}
+
+    total_light = sum(channel for row in result.image.pixels for pixel in row for channel in pixel)
+    assert total_light > 0.0
+
+    output_path = tmp_path / "chart.png"
+    result.save(str(output_path))
+    assert output_path.exists()

--- a/tests/test_sampling.py
+++ b/tests/test_sampling.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import math
+import random
+
+from star_chart_generator.config import Camera, CoreDistribution, HaloDistribution, Resolution, StarConfig
+from star_chart_generator.sampling import generate_star_field, render_star_field
+
+
+def _average(values: list[float]) -> float:
+    return sum(values) / max(len(values), 1)
+
+
+def test_star_field_distribution():
+    resolution = Resolution(width=256, height=256, ssaa=1)
+    camera = Camera(tilt_deg=28, fov_deg=35)
+    config = StarConfig(
+        core=CoreDistribution(sigma=0.22, alpha=3.0, count=200),
+        halo=HaloDistribution(count=150, min_r=0.45, max_r=1.05),
+        brightness_power=1.6,
+        min_size_px=0.6,
+        max_size_px=2.2,
+    )
+
+    stars = generate_star_field(config, resolution, camera, rng=random.Random(1234))
+    assert len(stars) == config.core.count + config.halo.count
+
+    image = render_star_field(stars, resolution)
+    assert image.width == resolution.width
+    assert image.height == resolution.height
+
+    total_light = sum(pixel[channel] for row in image.pixels for pixel in row for channel in range(3))
+    assert total_light > 0.0
+
+    cx, cy = resolution.width / 2.0, resolution.height / 2.0
+    ellipse_ratio = camera.ellipse_ratio
+    core_radii = []
+    for star in stars[: config.core.count]:
+        dx = star.x - cx
+        dy = (star.y - cy) / ellipse_ratio
+        core_radii.append(math.hypot(dx, dy))
+    halo_radii = []
+    for star in stars[config.core.count :]:
+        dx = star.x - cx
+        dy = (star.y - cy) / ellipse_ratio
+        halo_radii.append(math.hypot(dx, dy))
+
+    assert _average(core_radii) < _average(halo_radii)


### PR DESCRIPTION
## Summary
- add a standard-library-only rendering pipeline with sampling, geometry, text layout, and post-processing modules
- provide a CLI that renders YAML scenes to PNG files and optional layer exports
- add configuration presets, documentation updates, and regression tests for sampling, labels, and end-to-end rendering

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ca8ab73408832880a8e56b3231e550