### PR TITLE
Add configurable readout annotations with linear label support

### DIFF
--- a/configs/demo.yaml
+++ b/configs/demo.yaml
@@ -26,6 +26,21 @@ rings:
     color: "#FFC107"
     ticks_every_deg: 20
     label: "RELAY 7"
+readouts:
+  - text: "ENERGY 73%"
+    alignment: end
+    placement:
+      type: arc
+      ring: 1
+      angle_deg: 228
+      offset: 0.04
+  - text: "ΔV 12.4"
+    alignment: center
+    placement:
+      type: linear
+      ring: 2
+      angle_deg: 48
+      offset: 0.015
 stars:
   core:
     sigma: 0.20

--- a/src/star_chart_generator/shapes.py
+++ b/src/star_chart_generator/shapes.py
@@ -94,6 +94,34 @@ def render_ui_layers(config: SceneConfig, resolution: Tuple[int, int]) -> Tuple[
                 )
             )
 
+    for readout in config.readouts:
+        ring_index = readout.placement.ring_index
+        if ring_index < 0 or ring_index >= len(config.rings):
+            continue
+        ring = config.rings[ring_index]
+        if readout.placement.radius is not None:
+            label_radius = readout.placement.radius
+        else:
+            label_radius = ring.r + readout.placement.radial_offset
+        label_rx = base_radius * label_radius
+        label_ry = label_rx * ellipse_ratio
+        angle = math.radians(readout.placement.angle_deg)
+        baseline = "linear" if readout.placement.kind == "linear" else "arc"
+        label_specs.append(
+            LabelSpec(
+                ring_index=ring_index,
+                text=readout.text,
+                center=center,
+                radius_x=label_rx,
+                radius_y=label_ry,
+                initial_angle=angle,
+                tracking=config.text.tracking,
+                scale=label_scale,
+                alignment=readout.alignment,
+                baseline=baseline,
+            )
+        )
+
     if label_specs:
         placements = layout_labels(label_specs)
         label_core, label_glow = draw_label_layers((width, height), placements, config.text)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,8 +1,28 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
+import star_chart_generator.labels as label_module
 from star_chart_generator import SceneConfig, generate_star_chart
+
+
+def _sample_energy(image, x: float, y: float, radius: int = 3) -> float:
+    total = 0.0
+    xi = int(round(x))
+    yi = int(round(y))
+    for dy in range(-radius, radius + 1):
+        py = yi + dy
+        if py < 0 or py >= image.height:
+            continue
+        row = image.pixels[py]
+        for dx in range(-radius, radius + 1):
+            px = xi + dx
+            if px < 0 or px >= image.width:
+                continue
+            pixel = row[px]
+            total += pixel[0] + pixel[1] + pixel[2]
+    return total
 
 
 def test_generate_star_chart(tmp_path: Path):
@@ -29,6 +49,28 @@ def test_generate_star_chart(tmp_path: Path):
                     "label_angle_deg": 120,
                 },
             ],
+            "readouts": [
+                {
+                    "text": "ENERGY 72%",
+                    "alignment": "end",
+                    "placement": {
+                        "type": "arc",
+                        "ring": 0,
+                        "angle_deg": 220,
+                        "offset": 0.035,
+                    },
+                },
+                {
+                    "text": "Ω 114",
+                    "alignment": "center",
+                    "placement": {
+                        "type": "linear",
+                        "ring": 1,
+                        "angle_deg": 32,
+                        "offset": 0.012,
+                    },
+                },
+            ],
             "stars": {
                 "core": {"sigma": 0.2, "alpha": 3.1, "count": 200},
                 "halo": {"count": 120, "min_r": 0.4, "max_r": 1.0},
@@ -53,6 +95,35 @@ def test_generate_star_chart(tmp_path: Path):
 
     total_light = sum(channel for row in result.image.pixels for pixel in row for channel in pixel)
     assert total_light > 0.0
+
+    ui_core = result.layers["ui_core"]
+    base_radius = min(config.resolution.width, config.resolution.height) * 0.5 * 0.92
+    ellipse_ratio = config.camera.ellipse_ratio
+    label_scale = max(1.0, config.text.size_px / (7 * 2.0))
+
+    for readout in config.readouts:
+        placement = readout.placement
+        ring = config.rings[placement.ring_index]
+        radius_ratio = (
+            placement.radius
+            if placement.radius is not None
+            else ring.r + placement.radial_offset
+        )
+        rx = base_radius * radius_ratio
+        ry = rx * ellipse_ratio
+        theta = math.radians(placement.angle_deg)
+        advances = label_module._text_advances(readout.text, config.text.tracking)
+        arc_length = sum(advances) * label_scale
+        effective_radius = max((rx + ry) * 0.5, 1.0)
+        arc_angle = arc_length / effective_radius
+        if readout.alignment == "start":
+            theta += arc_angle / 2.0
+        elif readout.alignment == "end":
+            theta -= arc_angle / 2.0
+        cx = config.resolution.width / 2.0 + rx * math.cos(theta)
+        cy = config.resolution.height / 2.0 + ry * math.sin(theta)
+        energy = _sample_energy(ui_core, cx, cy, radius=3)
+        assert energy > 0.0
 
     output_path = tmp_path / "chart.png"
     result.save(str(output_path))


### PR DESCRIPTION
## Summary
- add readout configuration types and YAML parsing to describe readout text, alignment, and placement
- render readouts as curved or linear labels alongside rings
- document readouts in the demo scene and add regression coverage that samples UI energy at readout locations

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cab450e3508328afe4081ee63f80a7