### PR TITLE
Add camera ellipse ratio support and refine HUD defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,12 @@ Scene files are plain YAML documents. The most important sections are:
 
 - `seed`: base random seed used when `--seed` is not provided.
 - `resolution`: output width, height, and supersampling factor (`ssaa`).
-- `camera`: controls the tilt and field of view used to squash rings.
+- `camera`: controls the tilt and field of view used to squash rings. You can express the orientation as `pitch_deg`, `tilt_deg`, or directly as `ellipse_ratio` (the vertical squish factor, where `0.82` ≈ `35°`).
 - `rings`: list of UI rings. Each ring supports radius (`r`), width, colour, dash pattern, tick marks, labels, label angle, halo strength, etc.
 - `stars`: parameters for the dense core and sparse halo distributions, plus star size and brightness behaviour.
 - `text`: typography settings (font name, size, colour, tracking, tabular digits).
 - `post`: post-processing (bloom threshold/intensity/radius, chromatic aberration, vignette, grain).
+- `hud`: optional bottom band. Omit the section to keep the factory readouts, define your own under `hud.readouts`, or set `hud.readouts: []` / `hud.enabled: false` for a clean star chart.
 
 Use `configs/demo.yaml` or `configs/denso.yaml` as a template for your own layouts. Adjust one value at a time, rerun the renderer, and inspect the result to learn what each setting does.
 

--- a/docs/star_chart_generator_study.md
+++ b/docs/star_chart_generator_study.md
@@ -92,8 +92,9 @@ Este documento describe el objetivo visual, la arquitectura recomendada, el pipe
 - **Anillos**: número, radios, grosores, colores, *dash*, opacidad, radio del *glow*.
 - **Estrellas**: cuenta total, σ/α del núcleo, γ de brillo, tamaño mínimo/máximo, rampa de color.
 - **Etiquetas**: fuentes, tamaños, *arc padding*, reglas anti-colisión, *leader lines* (on/off).
-- **Cámara**: inclinación, FOV, *tilt-shift*, DOF on/off.
+- **Cámara**: inclinación (en `pitch_deg`/`tilt_deg` o `ellipse_ratio`), FOV, *tilt-shift*, DOF on/off.
 - **Post**: threshold/intensidad de bloom, aberración cromática, vignette, LUT.
+- **HUD**: banda inferior opcional; usar presets por defecto, definir `readouts` propios o desactivarlo.
 - **Exportes**: PNG 8-bit, TIFF/EXR 16-bit, PSD por capas (UI/estrellas/post).
 
 ### Formato de escena sugerido (YAML)

--- a/src/star_chart_generator/shapes.py
+++ b/src/star_chart_generator/shapes.py
@@ -306,7 +306,11 @@ def render_ui_layers(
         core.add_image(label_core)
         glow.add_image(gaussian_blur(label_glow, 2.0 * ssaa))
 
-    hud_readouts = config.hud.readouts or _DEFAULT_HUD_READOUTS
+    if config.hud.use_default_readouts and not config.hud.readouts:
+        hud_readouts: Sequence[HUDReadout] = _DEFAULT_HUD_READOUTS
+    else:
+        hud_readouts = config.hud.readouts
+
     if config.hud.enabled and hud_readouts:
         text_color = hex_to_rgb(config.text.color)
         _draw_hud(


### PR DESCRIPTION
## Summary
- allow scene configurations to set the camera tilt through an ellipse_ratio value alongside pitch/tilt degrees
- improve HUD parsing so explicit empty readout lists disable the band while preserving default presets when omitted
- document the new options and cover them with regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cae6f184b88328844e96e3e83e61bd